### PR TITLE
🔧 Added Issue Templates (Bug, Feature Request, Docs)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: 🐛 Bug Report
 about: Create a report to help us improve
-title: "[BUG] <title>"
+title: "[bug] <title>"
 labels: bug
 assignees: ''
 ---

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: 🐛 Bug Report
+about: Create a report to help us improve
+title: "[BUG] <title>"
+labels: bug
+assignees: ''
+---
+
+## 🐞 Describe the bug
+A clear and concise description of what the bug is.
+
+## 📍 To Reproduce
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '...'
+3. See error
+
+## 🧩 Expected behavior
+A clear and concise description of what you expected to happen.
+
+## 💻 Screenshots or Logs
+If applicable, add screenshots or error logs to help explain your problem.
+
+## 🧪 Environment
+- OS: [e.g. Ubuntu 22.04]
+- Browser [e.g. Chrome 116]
+- CLI Version:
+- Node Version:
+- Any other info:
+
+## ✅ Additional context
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/documentation_feedback.md
+++ b/.github/ISSUE_TEMPLATE/documentation_feedback.md
@@ -1,0 +1,16 @@
+---
+name: 📚 Documentation Feedback
+about: Suggest improvements to our documentation
+title: "[DOC] <title>"
+labels: documentation
+assignees: ''
+---
+
+## 📖 Describe the documentation issue
+What part of the documentation was unclear or incorrect?
+
+## 📌 Suggest a fix
+What would make it clearer or more accurate?
+
+## ✅ Additional context
+Add any extra context or screenshots if needed.

--- a/.github/ISSUE_TEMPLATE/documentation_feedback.md
+++ b/.github/ISSUE_TEMPLATE/documentation_feedback.md
@@ -1,7 +1,7 @@
 ---
 name: 📚 Documentation Feedback
 about: Suggest improvements to our documentation
-title: "[DOC] <title>"
+title: "[doc] <title>"
 labels: documentation
 assignees: ''
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: 🚀 Feature Request
+about: Suggest a new idea or enhancement
+title: "[FEATURE] <title>"
+labels: enhancement
+assignees: ''
+---
+
+## 📌 Describe the feature
+What problem does it solve? What benefit does it add?
+
+## 💡 Describe the solution you'd like
+A clear and concise description of what you want to happen.
+
+## 🔁 Describe alternatives you’ve considered
+Any alternative solutions or features you’ve thought about.
+
+## ✅ Additional context
+Add any other context or examples here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,8 +1,8 @@
 ---
 name: 🚀 Feature Request
 about: Suggest a new idea or enhancement
-title: "[FEATURE] <title>"
-labels: enhancement
+title: "[feat] <title>"
+labels: feature
 assignees: ''
 ---
 


### PR DESCRIPTION
This PR adds 3 issue templates under `.github/ISSUE_TEMPLATE/`:

- 🐛 Bug Report
- 🚀 Feature Request
- 📚 Documentation Feedback

Tested on my fork and confirmed all templates appear correctly when clicking “New Issue”.

Fixes #21
